### PR TITLE
Refs patch

### DIFF
--- a/src/Writer.luau
+++ b/src/Writer.luau
@@ -262,6 +262,11 @@ end
 function Writer.moveCursor(self: types.WriterData, delta: number)
 	insert(self._queue, { OP_MOV, delta })
 end
+
+function Writer.addRef(self: types.WriterData, ref: any)
+        self.nRefs += 1
+        self.refs[self.nRefs] = ref
+end
 ----
 
 local WriteFunctions: { (buffer, number, ...any) -> number } = {
@@ -411,6 +416,8 @@ end
 ]=]
 function Writer.new(): types.WriterData
 	local self = {}
+
+        self.nRefs = 0
 
 	self._len = 0
 	self._queue = {}

--- a/src/types.luau
+++ b/src/types.luau
@@ -31,6 +31,7 @@ export type Reader = {
 
 export type WriterData = {
 	refs: refs,
+        nRefs: number,
 	_len: number,
 	_queue: { { any } },
 }
@@ -51,6 +52,7 @@ export type Writer = {
 	read f32: (self: WriterData, value: number) -> (),
 	read f64: (self: WriterData, value: number) -> (),
 	read string: (self: WriterData, value: string, count: number?) -> (number, () -> ()), -- Returns the string's length in bytes and a function to actually write the string
+        read addRef: (self: WriterData, ref: any) -> (),
 
 	read Finalize: (self: WriterData) -> buffer,
 


### PR DESCRIPTION
fixes undefined behaviour when adding a nil ref

- adds writer function addRef to streamline reference insertion

since the packet should always be read in the same order it was written, we do not need to store any overhead in the buffer for the reference index

the ref can be read with
```lua
local ref = table.remove(reader.refs, 1)
```